### PR TITLE
fixed small bug for undo and redo methods in actionhistory

### DIFF
--- a/progress-logs/victor-logs
+++ b/progress-logs/victor-logs
@@ -24,4 +24,5 @@ selection tool finally able to select new areas and always white out whatevers s
 issue of not being able to draw over pasted selections, working on that!
 added cut and pasterecord to keep track of selected and pasted selections.
 2025-08-03: selection tool functionality fully functional, all bugs related to layering, drawing new strokes or erasing
-solved. Going to start on refactoring drawing canvas code.
+solved. Going to start on refactoring drawing canvas code. Fixed small bug where first item on
+the actionhistory stacks wouldnt undo or be able to redo from first deleted item.

--- a/src/main/java/entity/ActionHistory.java
+++ b/src/main/java/entity/ActionHistory.java
@@ -21,7 +21,13 @@ public class ActionHistory {
     }
 
     public Drawable undo() {
-        if (undoStack.isEmpty()) return null;
+        if (currentState == null) return null; // nothing to do
+        if (undoStack.isEmpty()){ // first action on canvas
+            redoStack.push(currentState); // save it for redo
+            currentState = null;
+            return currentState;
+        }
+        // code below from before
         redoStack.push(currentState);
         currentState = undoStack.pop();
         return currentState;
@@ -29,7 +35,9 @@ public class ActionHistory {
 
     public Drawable redo() {
         if (redoStack.isEmpty()) return null;
-        undoStack.push(currentState);
+        if (currentState != null) { // might be null after the first redo
+            undoStack.push(currentState);
+        }
         currentState = redoStack.pop();
         return currentState;
     }


### PR DESCRIPTION
fixed bug where first action on drawing canvas wouldnt undo when pressing ctrl z/undo buttons, thus not being able to redo