### PR TITLE
Canvas select screen is functional; imports the selected canvas

### DIFF
--- a/progress-logs/josh-logs
+++ b/progress-logs/josh-logs
@@ -63,3 +63,8 @@ canvas image data is fed through the login use case interface adapter, since the
 ## App
 #### LoginUseCaseFactory, Main
 - constructor for LoginInteractor was updated, so some data access objects had to be added to parameters
+
+2025-08-07 Implemented "Import/Retrieve Existing Canvas"
+General description: The canvas select screen in the previous entry was non-functional. Now, when you click
+on a canvas, it immediately imports that image.
+Details in pull request #77 (?)

--- a/src/main/java/app/CanvasUseCaseFactory.java
+++ b/src/main/java/app/CanvasUseCaseFactory.java
@@ -1,6 +1,7 @@
 package app;
 
 import interface_adapter.ViewManagerModel;
+import interface_adapter.canvas.CanvasViewModel;
 import interface_adapter.goback.GoBackController;
 import interface_adapter.goback.GoBackPresenter;
 import interface_adapter.goback.GoBackViewModel;
@@ -24,11 +25,13 @@ public final class CanvasUseCaseFactory {
 
     /**
      * Factory function for creating the CanvasView.
-     * @param viewManagerModel the ViewManagerModel to inject into the CanvasView
-     * @param goBackViewModel the NewCanvasViewModel to inject into the CanvasView
-     * @param newCanvasViewModel the CanvasViewModel to inject into the CanvasView
-     * @param signupViewModel the SignupViewModel to inject into the CanvasView
+     *
+     * @param viewManagerModel     the ViewManagerModel to inject into the CanvasView
+     * @param goBackViewModel      the NewCanvasViewModel to inject into the CanvasView
+     * @param newCanvasViewModel   the CanvasViewModel to inject into the CanvasView
+     * @param signupViewModel      the SignupViewModel to inject into the CanvasView
      * @param userDataAccessObject the GoBackUserDataAccessInterface to inject into the CanvasView
+     * @param canvasViewModel
      * @return the CanvasView created for the provided input classes
      */
     public static CanvasView create(
@@ -36,11 +39,12 @@ public final class CanvasUseCaseFactory {
             GoBackViewModel goBackViewModel,
             NewCanvasViewModel newCanvasViewModel,
             SignupViewModel signupViewModel,
-            GoBackUserDataAccessInterface userDataAccessObject) {
+            GoBackUserDataAccessInterface userDataAccessObject,
+            CanvasViewModel canvasViewModel) {
 
         final GoBackController goBackController = createGoBackUseCase(viewManagerModel, newCanvasViewModel,
                 signupViewModel, userDataAccessObject);
-        return new CanvasView(goBackViewModel, goBackController);
+        return new CanvasView(canvasViewModel, goBackViewModel, goBackController);
 
     }
 

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -70,7 +70,7 @@ public class Main {
 
         final CanvasView canvasView = CanvasUseCaseFactory.create(viewManagerModel, goBackViewModel,
                                                                 newCanvasViewModel, signupViewModel,
-                userDataAccessObject);
+                userDataAccessObject, canvasViewModel);
 
         views.add(canvasView, canvasView.getViewName());
 

--- a/src/main/java/app/MainInMemory.java
+++ b/src/main/java/app/MainInMemory.java
@@ -3,8 +3,6 @@ package app;
 import com.formdev.flatlaf.FlatLightLaf;
 import data_access.InMemoryCanvasDataAccessObject;
 import data_access.InMemoryUserDataAccessObject;
-import data_access.SupabaseAccountRepository;
-import data_access.SupabaseCanvasRepository;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.canvas.CanvasViewModel;
 import interface_adapter.goback.GoBackViewModel;
@@ -73,7 +71,7 @@ public class MainInMemory {
 
         final CanvasView canvasView = CanvasUseCaseFactory.create(viewManagerModel, goBackViewModel,
                                                                 newCanvasViewModel, signupViewModel,
-                userDataAccessObject);
+                userDataAccessObject, canvasViewModel);
 
         views.add(canvasView, canvasView.getViewName());
 

--- a/src/main/java/interface_adapter/canvas/CanvasState.java
+++ b/src/main/java/interface_adapter/canvas/CanvasState.java
@@ -1,11 +1,23 @@
 package interface_adapter.canvas;
 
+import java.awt.image.BufferedImage;
+
 /**
  * The State information representing a canvas.
  */
 public class CanvasState {
+    private BufferedImage initialImportedImage; // canvas select screen
+
     // Because of the previous copy constructor, the default constructor must be explicit.
     public CanvasState() {
 
+    }
+
+    public BufferedImage getInitialImportedImage() {
+        return initialImportedImage;
+    }
+
+    public void setInitialImportedImage(BufferedImage initialImportedImage) {
+        this.initialImportedImage = initialImportedImage;
     }
 }

--- a/src/main/java/interface_adapter/canvas/CanvasViewModel.java
+++ b/src/main/java/interface_adapter/canvas/CanvasViewModel.java
@@ -2,6 +2,8 @@ package interface_adapter.canvas;
 
 import interface_adapter.ViewModel;
 
+import java.awt.image.BufferedImage;
+
 /**
  * The View Model for the Canvas View.
  */
@@ -12,4 +14,8 @@ public class CanvasViewModel extends ViewModel<CanvasState> {
         setState(new CanvasState());
     }
 
+    public void setInitialImportedImage(BufferedImage initialImportedImage) {
+        this.getState().setInitialImportedImage(initialImportedImage);
+        firePropertyChanged("import");
+    }
 }

--- a/src/main/java/interface_adapter/newcanvas/NewCanvasController.java
+++ b/src/main/java/interface_adapter/newcanvas/NewCanvasController.java
@@ -3,6 +3,8 @@ package interface_adapter.newcanvas;
 import use_case.newcanvas.NewCanvasInputBoundary;
 import use_case.newcanvas.NewCanvasInputData;
 
+import java.awt.image.BufferedImage;
+
 /**
  * The controller for the New Canvas Screen Use Case.
  */
@@ -21,9 +23,16 @@ public class NewCanvasController {
      */
     public void execute(String username, String password) {
         final NewCanvasInputData newCanvasInputData = new NewCanvasInputData(
-                username, password);
+                username, password, null);
 
         newCanvasUseCaseInteractor.execute(newCanvasInputData);
+    }
+
+    public void execute(String username, String password, BufferedImage importedCanvas) {
+        final NewCanvasInputData newCanvasInputData = new NewCanvasInputData(
+                username, password, importedCanvas
+        );
+        newCanvasUseCaseInteractor.executeImportExistingCanvas(newCanvasInputData);
     }
 
     public void switchToSignupView() {

--- a/src/main/java/interface_adapter/newcanvas/NewCanvasPresenter.java
+++ b/src/main/java/interface_adapter/newcanvas/NewCanvasPresenter.java
@@ -33,12 +33,14 @@ public class NewCanvasPresenter implements NewCanvasOutputBoundary {
 
     @Override
     public void prepareSuccessView(NewCanvasOutputData newCanvasOutputData) {
-        /* *CODE REPLACED IN LOGIN PRESENTER* populate new canvas view state
-        List<BufferedImage> userCanvases = newCanvasOutputData.getUserExistingCanvases();
-        this.newCanvasViewModel.getState().setCanvases(userCanvases);
-        this.newCanvasViewModel.firePropertyChanged(); */
+        /* if an imported canvas is provided, import it into canvasViewModel */
+        BufferedImage importedCanvas = newCanvasOutputData.getImportedCanvas();
 
         final CanvasState canvasState = this.canvasViewModel.getState();
+        if (importedCanvas != null) {
+            // fires property change called "initialImportedImage"
+            canvasViewModel.setInitialImportedImage(importedCanvas);
+        }
         this.canvasViewModel.setState(canvasState);
         this.canvasViewModel.firePropertyChanged();
 

--- a/src/main/java/use_case/newcanvas/NewCanvasInputBoundary.java
+++ b/src/main/java/use_case/newcanvas/NewCanvasInputBoundary.java
@@ -13,6 +13,13 @@ public interface NewCanvasInputBoundary {
      * @param newCanvasInputData the input data
      */
     void execute(NewCanvasInputData newCanvasInputData);
+
+    /**
+     * Executes the login use case when importing an existing canvas.
+     * @param newCanvasInputData the input data
+     */
+    void executeImportExistingCanvas(NewCanvasInputData newCanvasInputData);
+
     void switchToSignupView();
     List<BufferedImage> getUserCanvases(NewCanvasInputData newCanvasInputData);
 }

--- a/src/main/java/use_case/newcanvas/NewCanvasInputData.java
+++ b/src/main/java/use_case/newcanvas/NewCanvasInputData.java
@@ -1,5 +1,7 @@
 package use_case.newcanvas;
 
+import java.awt.image.BufferedImage;
+
 /**
  * The Input Data for the New Canvas Use Case.
  */
@@ -7,10 +9,12 @@ public class NewCanvasInputData {
 
     private final String username;
     private final String password;
+    private final BufferedImage importedCanvas;
 
-    public NewCanvasInputData(String username, String password) {
+    public NewCanvasInputData(String username, String password, BufferedImage importedCanvas) {
         this.username = username;
         this.password = password;
+        this.importedCanvas = importedCanvas;
     }
 
     String getUsername() {
@@ -21,4 +25,7 @@ public class NewCanvasInputData {
         return password;
     }
 
+    public BufferedImage getImportedCanvas() {
+        return importedCanvas;
+    }
 }

--- a/src/main/java/use_case/newcanvas/NewCanvasInteractor.java
+++ b/src/main/java/use_case/newcanvas/NewCanvasInteractor.java
@@ -27,7 +27,20 @@ public class NewCanvasInteractor implements NewCanvasInputBoundary {
         */
 
         newCanvasPresenter.prepareSuccessView(
-                new NewCanvasOutputData(username)
+                new NewCanvasOutputData(username, null)
+        );
+    }
+
+    /**
+     * Alternative execution where a canvas is immediately imported
+     * @param newCanvasInputData input data
+     */
+    public void executeImportExistingCanvas(NewCanvasInputData newCanvasInputData) {
+        String username = newCanvasInputData.getUsername();
+        BufferedImage importedCanvas = newCanvasInputData.getImportedCanvas();
+
+        newCanvasPresenter.prepareSuccessView(
+                new NewCanvasOutputData(username, importedCanvas)
         );
     }
 

--- a/src/main/java/use_case/newcanvas/NewCanvasOutputData.java
+++ b/src/main/java/use_case/newcanvas/NewCanvasOutputData.java
@@ -1,6 +1,7 @@
 package use_case.newcanvas;
 
 import java.awt.image.BufferedImage;
+import java.nio.Buffer;
 import java.util.List;
 
 /**
@@ -9,13 +10,27 @@ import java.util.List;
 public class NewCanvasOutputData {
 
     private final String username;
+    private BufferedImage importedCanvas;
 
-    public NewCanvasOutputData(String username) {
+    public NewCanvasOutputData(String username,  BufferedImage importedCanvas) {
         this.username = username;
+        this.importedCanvas = importedCanvas;
     }
 
     public String getUsername() {
         return username;
+    }
+
+    /**
+     * Get the initially imported canvas
+     * @return Canvas to import, possibly null
+     */
+    public BufferedImage getImportedCanvas() {
+        return importedCanvas;
+    }
+
+    public void setImportedCanvas(BufferedImage canvasToImport) {
+        this.importedCanvas = canvasToImport;
     }
 
 }

--- a/src/main/java/view/CanvasView.java
+++ b/src/main/java/view/CanvasView.java
@@ -1,31 +1,51 @@
 package view;
 
 import entity.DrawingCanvas;
+import interface_adapter.canvas.CanvasState;
 import interface_adapter.canvas.CanvasViewModel;
 import interface_adapter.goback.GoBackController;
 import interface_adapter.goback.GoBackState;
 import interface_adapter.goback.GoBackViewModel;
+import interface_adapter.image.import_image.ImportController;
+import view.MidMenuBar.ImageBar.ImportButton;
 import view.MidMenuBar.MidMenuBarBuilder;
 import view.TopMenuBar.MenuActionListener;
 import view.TopMenuBar.TopMenuBarBuilder;
 
+import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.IOException;
 
 /**
  * The View for when the user is drawing on a canvas.
  */
-public class CanvasView extends JPanel implements ActionListener, MenuActionListener {
+public class CanvasView extends JPanel implements ActionListener, MenuActionListener,
+        PropertyChangeListener {
     private final String viewName = "canvas";
+    private final CanvasViewModel canvasViewModel;
     private final GoBackViewModel goBackViewModel;
     private final GoBackController goBackController;
     private final DrawingCanvas canvas;
 
-    public CanvasView(GoBackViewModel goBackViewModel, GoBackController goBackController) {
+    // TODO: Josh: I don't know a better way to import when getting canvases
+    // store the import button and then press it when we log in with an existing canvas.
+    private final ImportButton importButton;
+
+    public CanvasView(CanvasViewModel canvasViewModel, GoBackViewModel goBackViewModel, GoBackController goBackController) {
         this.goBackViewModel = goBackViewModel;
         this.goBackController = goBackController;
+
+        // JOSH: listen for changes in canvas state
+        this.canvasViewModel = canvasViewModel;
+        this.canvasViewModel.addPropertyChangeListener(this);
+
         this.setLayout(new BorderLayout());
         this.setPreferredSize(new Dimension(800, 600));
 
@@ -37,6 +57,9 @@ public class CanvasView extends JPanel implements ActionListener, MenuActionList
 
         MidMenuBarBuilder midMenuBarBuilder = new MidMenuBarBuilder(canvas);
         JPanel panel = midMenuBarBuilder.getPanel();
+        // store import button for use in login (in property change)
+        this.importButton = midMenuBarBuilder.getImportButtonObject();
+
         JPanel bottomPanel = new JPanel();
         bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.Y_AXIS));
         bottomPanel.add(panel);
@@ -70,6 +93,31 @@ public class CanvasView extends JPanel implements ActionListener, MenuActionList
                     currentState.getPassword(),
                     command
             );
+        }
+    }
+
+    /**
+     * Helper for propertyChange(). Directly accesses the import controller with a specific image
+     */
+    private void pressImportButton(ImportButton importButtonObject, BufferedImage initialImportedImage) {
+        ImportController controller = importButtonObject.getController();
+        File outputFile = new File("imageToImport.png");
+        try {
+            ImageIO.write(initialImportedImage, "png", outputFile);
+        } catch (IOException e) {
+            System.out.println("Failed to import initial image.");
+            throw new RuntimeException(e);
+        }
+
+        controller.execute(outputFile);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt) {
+        // System.out.println(evt.getPropertyName());
+        final CanvasState state = (CanvasState) evt.getNewValue();
+        if ("import".equals(evt.getPropertyName())) {
+            pressImportButton(this.importButton, state.getInitialImportedImage());
         }
     }
 }

--- a/src/main/java/view/MidMenuBar/ImageBar/ImportButton.java
+++ b/src/main/java/view/MidMenuBar/ImageBar/ImportButton.java
@@ -45,4 +45,8 @@ public class ImportButton {
     public JButton getButton() {
         return button;
     }
+
+    public ImportController getController() {
+        return controller;
+    }
 }

--- a/src/main/java/view/MidMenuBar/MidMenuBarBuilder.java
+++ b/src/main/java/view/MidMenuBar/MidMenuBarBuilder.java
@@ -45,6 +45,8 @@ public class MidMenuBarBuilder {
     JToggleButton colorWheelButton;
     DrawingCanvas canvas;
 
+    ImportButton importButtonObject;
+
     public MidMenuBarBuilder(DrawingCanvas canvas) {
         this.canvas = canvas;
         Paintbrush brush = canvas.getPaintbrush();
@@ -78,6 +80,7 @@ public class MidMenuBarBuilder {
 
         ImportButton imageButton = new ImportButton(importController);
         iButton = imageButton.getButton();
+        this.importButtonObject = imageButton; //  JOSH: Lol store it
 
         CropButton crop = new CropButton(cropController);
         cropButton = crop.getButton();
@@ -225,6 +228,14 @@ public class MidMenuBarBuilder {
 
     public JButton getEraseButton() {
         return eButton;
+    }
+
+    /**
+     * Getter for import button
+     * @return the import button
+     */
+    public ImportButton getImportButtonObject() {
+        return importButtonObject; // Josh: lol
     }
 
 }

--- a/src/main/java/view/MyCanvasesView.java
+++ b/src/main/java/view/MyCanvasesView.java
@@ -106,6 +106,8 @@ public class MyCanvasesView extends JPanel implements ActionListener, PropertyCh
      */
     private void refreshCanvasesPanel(JPanel subPanel) {
 
+        subPanel.removeAll();
+
         // Create the sub panel with horizontal layout
         subPanel.setLayout(new FlowLayout(FlowLayout.CENTER, 10, 10)); // horizontal with spacing
 
@@ -113,21 +115,39 @@ public class MyCanvasesView extends JPanel implements ActionListener, PropertyCh
         int iconHeight = 200;
 
         final NewCanvasState currentState = newCanvasViewModel.getState();
-        List<BufferedImage> listCanvases = newCanvasViewModel.getCanvases();
+        List<BufferedImage> listOfCanvasImages = newCanvasViewModel.getCanvases();
 
-        for (int i = 0; i < listCanvases.size(); i++) {
-            JButton square = new JButton();
+        for (BufferedImage oldCanvasImage : listOfCanvasImages) {
+            JButton canvasIconButton = new JButton();
 
-            ImageIcon icon = new ImageIcon(listCanvases.get(i));
+            ImageIcon icon = new ImageIcon(oldCanvasImage);
             //Image image = icon.getImage().getScaledInstance(iconWidth, iconHeight, java.awt.Image.SCALE_SMOOTH);
             Image image = getScaledImage(icon.getImage(), iconWidth, iconHeight);
 
-            square.setIcon(new ImageIcon(image));
+            canvasIconButton.setIcon(new ImageIcon(image));
 
-            square.setPreferredSize(new Dimension(iconWidth, iconHeight));
-            square.setBackground(Color.LIGHT_GRAY); // or any other color
-            square.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-            subPanel.add(square);
+            canvasIconButton.setPreferredSize(new Dimension(iconWidth, iconHeight));
+            canvasIconButton.setBackground(Color.LIGHT_GRAY); // or any other color
+            canvasIconButton.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+            subPanel.add(canvasIconButton);
+
+            // Execute login with new import image
+            canvasIconButton.addActionListener(
+                    new ActionListener() {
+                        public void actionPerformed(ActionEvent evt) {
+                            if (evt.getSource().equals(canvasIconButton)) {
+                                final NewCanvasState currentState = newCanvasViewModel.getState();
+
+                                // 3 parameter version executes an automatic import!!!
+                                newCanvasController.execute(
+                                        currentState.getUsername(),
+                                        currentState.getPassword(),
+                                        oldCanvasImage
+                                );
+                            }
+                        }
+                    }
+            );
         }
 
         this.revalidate();


### PR DESCRIPTION
hacked into ImportController it's a little nasty. 

## Changes for the Retrieve Existing Canvas functionality
2025-Aug-07 by Josh Villas

General description: The canvas select screen in the previous entry was non-functional. Now, when you click on a canvas, it immediately imports that image.

Title represents package/layer of changes

## App
#### Main. MainInMemory, CanvasUseCaseFactory
- constructor for CanvasView was modified, so parameters in were updated in the Factory (and thus also in Main) to reflect that.

## Frameworks & Drivers (View)
#### CanvasView
- create field canvasViewModel and add it to constructor parameters
- CanvasView now implements PropertyChangeListener, added this as listener to canvasViewModel
- create methods propertyChange, pressImportButton (helper)
- create field importButton to track the button
  - pressImportButton "reaches" into importButton to directly touch Lauren's existing ImportController 
#### MyCanvasesView
- add action listener to each canvas to execute the import use case
#### ImportButton
- create method getController 

## Interface Adapter
#### CanvasState
- create getter and setter for a new initialImportedImage field
#### CanvasViewModel
- create setInitialImportedImage, which sets it and fires a property change

#### NewCanvasController
- create alternative execute() method with 3 parameters. overloaded methods
  - if 2 parameters, then assume we are creating a new blank canvas.
  - if 3 parameters, we are explicitly passing a saved canvas to import. notify the interactor to do this execution.
#### NewCanvasPresenter
- added: if Interactor gave a canvas to import, update the canvasViewModel (thus fire property change) 

## Use Case / Business Rules
#### NewCanvasInputBoundary, NewCanvasInteractor
- create alternative execute method "executeImportExistingCanvas":
  - execute() is used to execute the use case for creating a **new blank canvas**
  - executeImportExistingCanvas() is used to execute the use case for creating a new canvas and **importing an existing image** (i.e. existing saved canvas)
#### NewCanvasInputData
- create field importedCanvas + getter method getImportedCanvas
  - explained further in NewCanvasController
#### NewCanvasOutputData
- create field importedCanvas + getter method getImportedCanvas
  - the use case now outputs the selected importedCanvas (possibly null, if creating a blank canvas)