### PR TITLE
dashed ants border bug fixed

### DIFF
--- a/src/main/java/view/DrawingView.java
+++ b/src/main/java/view/DrawingView.java
@@ -63,6 +63,7 @@ public class DrawingView extends JPanel implements MouseListener, MouseMotionLis
         controller.handleMouseReleased(e.getPoint(), getImage());
         renderCanvasView();
         renderer.updateAntsTimer(antsTimer, selectionViewModel);
+        repaint();
     }
 
     @Override
@@ -71,6 +72,7 @@ public class DrawingView extends JPanel implements MouseListener, MouseMotionLis
             controller.handleMousePressed(e.getPoint());
             renderCanvasView();
             renderer.updateAntsTimer(antsTimer, selectionViewModel);
+            repaint();
         }
     }
 
@@ -81,9 +83,14 @@ public class DrawingView extends JPanel implements MouseListener, MouseMotionLis
     }
 
     public BufferedImage getImage() {
+        // try only base snapshot: no selection overlay, no more overlay
         BufferedImage image = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = image.createGraphics();
-        this.paint(g2d);
+//        this.paint(g2d);
+        renderer.resize(g2d, viewModel);
+        renderer.drawImage(g2d, viewModel); // background strokes
+        renderer.renderDraw(g2d, viewModel); // commited strokes
+        renderer.layeringDraw(g2d, viewModel); // currentstroke head
         g2d.dispose();
         return image;
     }


### PR DESCRIPTION
Issue:
Fixed necessary code in DrawingView.java, where the bug lived.
After selection mode of the selected contents were drawing entire selection including border and pasting via drawingview object instead of seperate pasting working components in getImage().
Bug fixed by individually calling necessary methods in \InterFaceAdapter\Canvasrenderer.java to render what was needed.